### PR TITLE
Template for building Windows Arm64 MSYS2 package using Clang

### DIFF
--- a/.github/scripts/msys2/build-package.sh
+++ b/.github/scripts/msys2/build-package.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../../../config.sh
+
+PACKAGE_REPOSITORY=$1
+
+ARGUMENTS="--syncdeps \
+  --rmdeps \
+  --noconfirm \
+  --noprogressbar \
+  --skippgpcheck \
+  --force \
+  $([ "$NO_EXTRACT" = 1 ] && echo "--noextract" || echo "") \
+  $([ "$CLEAN_BUILD" = 1 ] && echo "--cleanbuild" || echo "") \
+  $([ "$INSTALL_PACKAGE" = 1 ] && echo "--install" || echo "")"
+
+if [ ! -f "PKGBUILD" ]; then
+  echo "PKGBUILD not found, aborting."
+  exit 1
+fi
+
+if command -v ccache &> /dev/null; then
+  echo "::group::Ccache statistics before build"
+    ccache -svv
+  echo "::endgroup::"
+fi
+
+echo "::group::Build package"
+  if [[ "$PACKAGE_REPOSITORY" == *MINGW* ]]; then
+    makepkg-mingw $ARGUMENTS
+  else
+    makepkg $ARGUMENTS
+  fi
+echo "::endgroup::"
+
+if command -v ccache &> /dev/null; then
+  echo "::group::Ccache statistics after build"
+    ccache -svv
+  echo "::endgroup::"
+fi

--- a/.github/scripts/msys2/enable-ccache.sh
+++ b/.github/scripts/msys2/enable-ccache.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../../../config.sh
+
+PACKAGE_REPOSITORY=$1
+
+DIR="`dirname ${BASH_SOURCE[0]}`/../../.."
+DIR=`realpath $DIR`
+CCACHE_DIR=$DIR/ccache
+if [[ -n "$GITHUB_WORKSPACE" ]]; then
+  echo "CCACHE_DIR=$CCACHE_DIR" >> "$GITHUB_ENV"
+  echo timestamp=$(date -u --iso-8601=seconds) >> "$GITHUB_OUTPUT"
+fi
+
+apply_patch () {
+  if patch -R -p1 --dry-run -b -i "$1" > /dev/null 2>&1; then
+    echo "Patch $1 is already applied"
+  else
+    patch -p1 -b -i "$1"
+  fi
+}
+
+mkdir -p $CCACHE_DIR
+
+pushd /
+  echo "::group::Enable ccache"
+    apply_patch "$DIR/patches/msys2/0001-ccache.patch"
+  echo "::endgroup::"
+popd
+
+if [[ "$PACKAGE_REPOSITORY" == *MINGW* ]]; then
+  pacman -S --noconfirm mingw-w64-clang-aarch64-ccache
+else
+  pacman -S --noconfirm ccache
+fi

--- a/.github/scripts/msys2/install-dependencies.sh
+++ b/.github/scripts/msys2/install-dependencies.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+source `dirname ${BASH_SOURCE[0]}`/../../../config.sh
+
+DEPENDENCIES=$1
+
+if [ -n "$DEPENDENCIES" ]; then
+  pacman -S --noconfirm \
+    $DEPENDENCIES
+fi

--- a/.github/workflows/clangarm64-msys2-package.yml
+++ b/.github/workflows/clangarm64-msys2-package.yml
@@ -1,0 +1,103 @@
+name: Build MSYS2 package with CLANGARM64
+
+on:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: "Package name to build"
+        type: string
+        default: "mingw-w64-zlib"
+      packages_repository:
+        description: "MSYS2 packages repository to build from"
+        type: string
+        default: "msys2/MINGW-packages"
+      packages_branch:
+        description: "MSYS2 packages branch to build from"
+        type: string
+        default: "master"
+      dependencies:
+        description: "Install additional dependencies"
+        type: string
+        default: ""
+
+env:
+  CLEAN_BUILD: 1
+
+jobs:
+  build:
+    name: Build ${{ inputs.package_name || 'mingw-w64-zlib' }}
+    timeout-minutes: 720
+    runs-on: windows-11-arm
+
+    defaults:
+     run:
+       shell: msys2 {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Checkout ${{ inputs.packages_repository || 'msys2/MINGW-packages' }} repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.packages_repository || 'msys2/MINGW-packages' }}
+          ref: ${{ inputs.packages_branch || 'master' }}
+          sparse-checkout: ${{ inputs.package_name || 'mingw-w64-zlib' }}
+          path: ${{ github.workspace }}/packages
+
+      - uses: msys2/setup-msys2@v2
+        timeout-minutes: 10
+        with:
+          msystem: ${{ contains(inputs.packages_repository || 'msys2/MINGW-packages', 'MINGW') && 'CLANGARM64' || 'MSYS' }}
+          path-type: minimal
+          install: git base-devel
+          update: true
+          cache: true
+
+      - name: Install dependencies
+        run: >-
+          `cygpath "${{ github.workspace }}"`/.github/scripts/msys2/install-dependencies.sh \
+            "${{ inputs.dependencies }}"
+
+      - name: Enable Ccache
+        id: enable-ccache
+        run: |
+          `cygpath "${{ github.workspace }}"`/.github/scripts/msys2/enable-ccache.sh \
+            ${{ inputs.packages_repository || 'msys2/MINGW-packages' }}
+
+      - name: Restore Ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ inputs.package_name || 'mingw-w64-zlib' }}-ccache-${{ steps.enable-ccache.outputs.timestamp }}
+          restore-keys: ${{ inputs.package_name || 'mingw-w64-zlib' }}-
+
+      - name: Build ${{ inputs.package_name || 'mingw-w64-zlib' }}
+        timeout-minutes: 720
+        working-directory: ${{ github.workspace }}/packages/${{ inputs.package_name || 'mingw-w64-zlib' }}
+        run: |
+          `cygpath "${{ github.workspace }}"`/.github/scripts/msys2/build-package.sh \
+            ${{ inputs.packages_repository || 'msys2/MINGW-packages' }}
+
+      - name: Save Ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/ccache
+          key: ${{ inputs.package_name || 'mingw-w64-zlib' }}-ccache-${{ steps.enable-ccache.outputs.timestamp }}
+
+      - name: Upload ${{ inputs.package_name || 'mingw-w64-zlib' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.package_name || 'mingw-w64-zlib' }}
+          retention-days: 3
+          path: ${{ github.workspace }}/packages/${{ inputs.package_name || 'mingw-w64-zlib' }}/*.pkg.tar.zst
+
+      - name: Upload build folder
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.package_name || 'mingw-w64-zlib' }}-build
+          retention-days: 1
+          path: ${{ github.workspace }}/packages/${{ inputs.package_name || 'mingw-w64-zlib' }}/src

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
-# GitHub Actions Templates
+# GitHub Actions Templates for Windows on Arm64
 
-A collection of reusable GitHub Actions workflows and templates for Windows on Arm64 projects.
+A collection of reusable GitHub Actions workflows and scripts to automate building Windows on Arm64
+(WoA) projects. These templates are designed to simplify CI/CD for open source and
+cross-platform development.
+
+## Contents
+
+### [clangarm64-msys2-package.yml](https://github.com/Windows-on-ARM-Experiments/github-actions-templates/blob/main/.github/workflows/clangarm64-msys2-package.yml)
+
+This workflow builds an MSYS2 package using the Clang compiler in the `CLANGARM64` environment.
+It checks out both your repository and the MSYS2 packages repository, installs dependencies,
+enables ccache, builds the package, and uploads the resulting artifacts.
+
+#### Inputs
+ - `package_name` (string): Package name to build (default: `mingw-w64-zlib`)
+ - `packages_repository` (string): MSYS2 packages repository to build from (default: `msys2/MINGW-packages`)
+ - `packages_branch` (string): MSYS2 packages branch to build from (default: `master`)
+ - `dependencies` (string): Additional dependencies to install (default: empty)
+
+#### Outputs
+ - Built package artifact (`*.pkg.tar.zst`)
+ - Build folder (on failure)
+
+#### Scripts
+The workflow uses helper scripts in `.github/scripts/msys2/`:
+ - `install-dependencies.sh`: Installs additional dependencies via `pacman`.
+ - `enable-ccache.sh`: Sets up `ccache` for faster builds and applies required patches.
+ - `build-package.sh`: Runs the package build process using `makepkg-mingw` or `makepkg`.

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e # exit on error
+set -x # echo on
+set -o pipefail # fail of any command in pipeline is an error
+
+CLEAN_BUILD=${CLEAN_BUILD:-0}
+INSTALL_PACKAGE=${INSTALL_PACKAGE:-0}
+NO_EXTRACT=${NO_EXTRACT:-0}

--- a/patches/msys2/0001-ccache.patch
+++ b/patches/msys2/0001-ccache.patch
@@ -1,0 +1,22 @@
+--- a/etc/makepkg.conf
++++ b/etc/makepkg.conf
+@@ -63,7 +63,7 @@
+ #-- check:    Run the check() function if present in the PKGBUILD
+ #-- sign:     Generate PGP signature file
+ #
+-BUILDENV=(!distcc color !ccache check !sign)
++BUILDENV=(!distcc color ccache check !sign)
+ #
+ #-- If using DistCC, your MAKEFLAGS will also need modification. In addition,
+ #-- specify a space-delimited list of hosts running in the DistCC cluster.
+--- a/etc/makepkg_mingw.conf
++++ b/etc/makepkg_mingw.conf
+@@ -137,7 +137,7 @@
+ #-- check:    Run the check() function if present in the PKGBUILD
+ #-- sign:     Generate PGP signature file
+ #
+-BUILDENV=(!distcc color !ccache check !sign)
++BUILDENV=(!distcc color ccache check !sign)
+ #
+ #-- If using DistCC, your MAKEFLAGS will also need modification. In addition,
+ #-- specify a space-delimited list of hosts running in the DistCC cluster.


### PR DESCRIPTION
Adds template workflow for building MSYS2 packages using Clang on public Arm64 GitHub Actions runners. See [README.md](https://github.com/Windows-on-ARM-Experiments/github-actions-templates/pull/1/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) for more details.